### PR TITLE
Changed Logo Link Address

### DIFF
--- a/worksheet1/cise-react-learn/src/App.js
+++ b/worksheet1/cise-react-learn/src/App.js
@@ -11,7 +11,7 @@ function App() {
         </p>
         <a
           className="App-link"
-          href="aut.ac.nz"
+          href="https://aut.ac.nz"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
This pull request changes the logo link address in the application. The previous link was the default link, and it has been replaced with a new address to allow users to access the AUT link. Please review the changes.